### PR TITLE
asteroid-launcher: Set working directory to fix graphics related warn…

### DIFF
--- a/recipes-asteroid/asteroid-gps/asteroid-gps_git.bb
+++ b/recipes-asteroid/asteroid-gps/asteroid-gps_git.bb
@@ -1,0 +1,14 @@
+SUMMARY = "Asteroid's GPS test app"
+HOMEPAGE = "https://github.com/AsteroidOS/asteroid-gps-test.git"
+LICENSE = "GPLv3"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
+
+SRC_URI = "git://github.com/AsteroidOS/asteroid-gps-test.git;protocol=https"
+SRCREV = "${AUTOREV}"
+PR = "r1"
+PV = "+git${SRCPV}"
+S = "${WORKDIR}/git"
+inherit qmake5
+
+DEPENDS += "qml-asteroid qtlocation qttools-native qtdeclarative-native"
+RDEPENDS:${PN} += "qtlocation"

--- a/recipes-asteroid/asteroid-launcher/asteroid-launcher/asteroid-launcher.service
+++ b/recipes-asteroid/asteroid-launcher/asteroid-launcher/asteroid-launcher.service
@@ -5,6 +5,7 @@ ConditionUser=!root
 
 [Service]
 Type=notify
+WorkingDirectory=/
 EnvironmentFile=-/var/lib/environment/compositor/*.conf
 ExecStartPre=/bin/sh -ec 'while [ ! -f /dev/.coldboot_done ]; do sleep 1; done'
 ExecStartPre=-/bin/sh -ec '/bin/echo QUIT > /run/psplash_fifo'

--- a/recipes-core/lcd-tools/lcd-tools.bb
+++ b/recipes-core/lcd-tools/lcd-tools.bb
@@ -1,0 +1,21 @@
+DESCRIPTION = "Daemon backend to control LCD functions"
+HOMEPAGE = "https://github.com/AsteroidOS/lcd-tools.git"
+LICENSE = "GPLv3"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=1ebbd3e34237af26da5dc08a4e440464"
+
+
+SRC_URI = "git://github.com/AsteroidOS/lcd-tools.git;branch=main;protocol=https"
+SRCREV = "${AUTOREV}"
+PR = "r0"
+PV = "+git${SRCPV}"
+S = "${WORKDIR}/git"
+DEPENDS = "libhybris cli11"
+inherit cmake pkgconfig
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+COMPATIBLE_MACHINE = "catfish"
+
+do_install:append() {
+    install -d ${D}/etc/systemd/system/timers.target.wants/
+    ln -s ../lcd-sync-time.timer ${D}/etc/systemd/system/timers.target.wants/lcd-sync-time.timer
+}
+


### PR DESCRIPTION
…ing.

The HWComposer on various watches tries to access 'sys/class/graphics/fb0/dyn_pu'.
Notice the missing / in front of sys. This makes it behave so that the path is only accessible when the compositor is started from the root directory.

Fixes this logcat warning: Failed to open sysfs node: sys/class/graphics/fb0/dyn_pu.

Signed-off-by: Darrel Griët <dgriet@gmail.com>